### PR TITLE
Fix anti-burn screen & Wrong position of Lyrics(Caused by anti-burn)

### DIFF
--- a/app/src/main/java/statusbar/lyric/hook/app/SystemUI.kt
+++ b/app/src/main/java/statusbar/lyric/hook/app/SystemUI.kt
@@ -174,7 +174,8 @@ class SystemUI : BaseHook() {
                     iconPos = config.getLyricPosition()
                     if (order) i += 1 else i -= 1
                     updateMargins.sendMessage(updateMargins.obtainMessage().also {
-                        it.obj = 10 + i + iconPos
+                        it.obj = null
+                        it.arg1 = 10 + i + iconPos
                         it.arg2 = config.getLyricHigh()
                     })
                     if (i == 0) order = true else if (i == 20) order = false


### PR DESCRIPTION
#### 修复防烧屏失效 & 由防烧屏导致的歌词左右位置错误
原代码在防烧屏移动歌词时会导致歌词左右位置错误（变回最初位置），并导致防烧屏后续无法运行（将左右位置改为100，防烧屏时间设置为1000后可明显观察到错误发生，并且后续歌词位置无轻微变动）