### PR TITLE
解决与米客模块-双排状态栏的冲突

### DIFF
--- a/app/src/main/java/statusbar/lyric/hook/app/SystemUILyric.kt
+++ b/app/src/main/java/statusbar/lyric/hook/app/SystemUILyric.kt
@@ -185,7 +185,7 @@ class SystemUILyric : BaseHook() {
                         "Lyric Init".log()
                         clockView = view as TextView
                         targetView = (clockView.parent as LinearLayout).apply {
-                            gravity = Gravity.CENTER
+                            gravity = Gravity.LEFT
                         }
                         canLoad = false
                         lyricInit()


### PR DESCRIPTION
在启用米客（Pengeek）模块的双排状态栏时，系统时间会变成状态栏左侧居中显示：
https://github.com/MonwF/customiuizer/issues/444
![未播放音乐，时间居中](https://github.com/Block-Network/StatusBarLyric/assets/25398342/d5ed65db-b68d-494a-a392-b5b18c93c202)

解决后：
![未播放音乐，时间左对齐](https://github.com/Block-Network/StatusBarLyric/assets/25398342/0b5d5cb2-f7f6-4f8e-9440-8fc7d555d53d)
![播放音乐时，时间左对齐并显示歌词](https://github.com/Block-Network/StatusBarLyric/assets/25398342/4d4e46dc-1157-47bb-a43b-29abbe92a9b7)

