### PR TITLE
调整重启系统界面的 dialog 显示逻辑

### DIFF
--- a/app/src/main/kotlin/statusbar/lyric/ui/page/MenuPage.kt
+++ b/app/src/main/kotlin/statusbar/lyric/ui/page/MenuPage.kt
@@ -295,9 +295,8 @@ fun RestartDialog(showDialog: MutableState<Boolean>) {
                 ) {
                     Button(
                         modifier = Modifier.weight(1f),
-                        text = stringResource(R.string.ok),
+                        text = stringResource(R.string.cancel),
                         onClick = {
-                            Tools.shell("killall com.android.systemui", true)
                             dismissDialog()
                             showDialog.value = false
                         }
@@ -305,9 +304,10 @@ fun RestartDialog(showDialog: MutableState<Boolean>) {
                     Spacer(Modifier.width(20.dp))
                     Button(
                         modifier = Modifier.weight(1f),
-                        text = stringResource(R.string.cancel),
+                        text = stringResource(R.string.ok),
                         submit = true,
                         onClick = {
+                            Tools.shell("killall com.android.systemui", true)
                             dismissDialog()
                             showDialog.value = false
                         }


### PR DESCRIPTION
原版中点击 “重启系统界面” 弹出的 dialog，确定位于左边且为白色，取消在右边且用提示色标重。

我认为这种设定不太符合客观需求：
1. 既然点击了 “重启系统界面” 那我的需求大概率是重启系统界面，而 dialog 却着重标明 “取消”， 容易误点。
2. 如果是想要着重提示，似乎有些多此一举了，因为弹出 dialog 本身就是一种提示。

））