### PR TITLE
修复隐藏通知图标在非播放状态生效的问题

### DIFF
--- a/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
+++ b/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
@@ -653,7 +653,6 @@ class SystemUILyric : BaseHook() {
                     }
                 }
             }
-            if (this::mNotificationIconArea.isInitialized) if (config.hideNotificationIcon) mNotificationIconArea.hideView() else mNotificationIconArea.showView()
         }
     }
 


### PR DESCRIPTION
应仅在播放时隐藏通知图标。