### PR TITLE
修复音乐标题不弹出、弹出其他应用视频标题、状态受其他应用干扰的问题。

### DIFF
--- a/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
+++ b/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
@@ -408,6 +408,7 @@ class SystemUILyric : BaseHook() {
     private val handler: Handler = Handler(Looper.getMainLooper())
     private var titleShowRunnable: Runnable? = null
     private var nowPlayingApp: String = ""
+    private var artist: String? = null
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag", "MissingPermission")
     private fun lyricInit() {
@@ -439,14 +440,19 @@ class SystemUILyric : BaseHook() {
             themeMode = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)
             if (config.titleSwitch) {
                 object : SystemMediaSessionListener(context) {
-                    override fun onTitleChanged(changedApp: String, title: String) {
-                        super.onTitleChanged(changedApp, title)
+                    override fun onTitleChanged(changedApp: String, title: String, artist: String) {
+                        super.onTitleChanged(changedApp, title, artist)
+                        val currentTitle = title
+                        val currentArtist = artist
                         titleShowRunnable = Runnable {
                             if (nowPlayingApp.isNotEmpty()) {
                                 if (changedApp.isNotEmpty() && nowPlayingApp != changedApp) return@Runnable
                             } else return@Runnable // 为空代表尚且没有播放的应用
-                            "title: $title".log()
-                            this@SystemUILyric.title = title
+                            if (this@SystemUILyric.artist != currentArtist) {
+                                "title: $title".log()
+                                this@SystemUILyric.artist = currentArtist
+                                this@SystemUILyric.title = currentTitle
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/statusbar/lyric/tools/SystemMediaSessionListener.kt
+++ b/app/src/main/kotlin/statusbar/lyric/tools/SystemMediaSessionListener.kt
@@ -9,7 +9,6 @@ import android.media.session.PlaybackState
 import android.service.notification.NotificationListenerService
 
 open class SystemMediaSessionListener(context: Context) {
-    private var artist: String? = null
     private var mediaSessionManager: MediaSessionManager? = null
     private val activeControllers = mutableMapOf<MediaController, MediaControllerCallback>()
 
@@ -72,10 +71,7 @@ open class SystemMediaSessionListener(context: Context) {
     private fun displayMediaMetadata(changedApp: String, metadata: MediaMetadata) {
         val title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "Unknown Title"
         val artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: "Unknown Artist"
-        if (this.artist != artist) {
-            this.artist = artist
-            onTitleChanged(changedApp, title)
-        }
+        onTitleChanged(changedApp, title, artist)
     }
 
     fun cleanup() {
@@ -83,7 +79,7 @@ open class SystemMediaSessionListener(context: Context) {
         activeControllers.entries.forEach { it.key.unregisterCallback(it.value) }
     }
 
-    open fun onTitleChanged(changedApp: String, title: String) {}
+    open fun onTitleChanged(changedApp: String, title: String, artist: String) {}
 
     open fun onStateChanged(changedApp: String, state: Int) {}
 

--- a/app/src/main/kotlin/statusbar/lyric/tools/SystemMediaSessionListener.kt
+++ b/app/src/main/kotlin/statusbar/lyric/tools/SystemMediaSessionListener.kt
@@ -11,7 +11,7 @@ import android.service.notification.NotificationListenerService
 open class SystemMediaSessionListener(context: Context) {
     private var artist: String? = null
     private var mediaSessionManager: MediaSessionManager? = null
-    private val activeControllers = mutableListOf<MediaController>()
+    private val activeControllers = mutableMapOf<MediaController, MediaControllerCallback>()
 
     // 监听活跃会话的变化
     private val activeSessionsListener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
@@ -19,13 +19,14 @@ open class SystemMediaSessionListener(context: Context) {
             onCleared()
         }
         // 清理之前的回调
-        activeControllers.forEach { it.unregisterCallback(mediaControllerCallback) }
+        activeControllers.entries.forEach { it.key.unregisterCallback(it.value) }
         activeControllers.clear()
 
         controllers?.let {
             it.forEach { controller ->
-                activeControllers.add(controller)
-                controller.registerCallback(mediaControllerCallback)
+                val callback = MediaControllerCallback(controller)
+                activeControllers[controller] = callback
+                controller.registerCallback(callback)
                 handleMediaController(controller)
             }
         }
@@ -41,49 +42,50 @@ open class SystemMediaSessionListener(context: Context) {
 
     private fun handleMediaController(controller: MediaController) {
         controller.metadata?.let { metadata ->
-            displayMediaMetadata(metadata)
+            displayMediaMetadata(controller.packageName, metadata)
         }
 
         controller.playbackState?.let { state ->
-            onStateChanged(state.state)
+            onStateChanged(controller.packageName, state.state)
         }
     }
 
     // MediaController 回调
-    private val mediaControllerCallback = object : MediaController.Callback() {
+    private inner class MediaControllerCallback(private val controller: MediaController) :
+        MediaController.Callback() {
         override fun onMetadataChanged(metadata: MediaMetadata?) {
             super.onMetadataChanged(metadata)
             metadata?.let {
-                displayMediaMetadata(it)
+                displayMediaMetadata(controller.packageName, it)
             }
         }
 
         override fun onPlaybackStateChanged(state: PlaybackState?) {
             super.onPlaybackStateChanged(state)
             state?.let {
-                onStateChanged(state.state)
+                onStateChanged(controller.packageName, state.state)
             }
         }
     }
 
     // 显示媒体元数据
-    private fun displayMediaMetadata(metadata: MediaMetadata) {
+    private fun displayMediaMetadata(changedApp: String, metadata: MediaMetadata) {
         val title = metadata.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "Unknown Title"
         val artist = metadata.getString(MediaMetadata.METADATA_KEY_ARTIST) ?: "Unknown Artist"
         if (this.artist != artist) {
             this.artist = artist
-            onTitleChanged(title)
+            onTitleChanged(changedApp, title)
         }
     }
 
     fun cleanup() {
         mediaSessionManager?.removeOnActiveSessionsChangedListener(activeSessionsListener)
-        activeControllers.forEach { it.unregisterCallback(mediaControllerCallback) }
+        activeControllers.entries.forEach { it.key.unregisterCallback(it.value) }
     }
 
-    open fun onTitleChanged(title: String) {}
+    open fun onTitleChanged(changedApp: String, title: String) {}
 
-    open fun onStateChanged(state: Int) {}
+    open fun onStateChanged(changedApp: String, state: Int) {}
 
     open fun onCleared() {}
 }


### PR DESCRIPTION
修复问题如题。

1. 由于 onUpdate 执行在 onTitleChanged 之后，这时播放状态尚未为 true，导致标题无法弹出。
2. 新代码包含包名校验，如果输入标题不是正在播放的目标应用的则忽略（可以解决获取到B站标题的问题）
3. 当修改比如B站视频的播放状态时，模块会捕捉到B站的状态变化并调用 onStop 导致歌词隐藏。
4. 某些状态下某些闹谭应用会使用 title 传递歌词而不只标题，在某些状态下会导致歌词被按标题展示，新逻辑尽量避免此现象（低概率还是会在首次展示时获取到标题外的内容，但不会再出现二次展示的情况了）。 （针对第二条补充pr）

提醒：如需合并本 pr，请务必合并稍后推送给 lyric getter 的 pr，因为它为此修改提供支持。