### PR TITLE
fix: 彻底解决和焦点通知冲突的问题

### DIFF
--- a/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
+++ b/app/src/main/kotlin/statusbar/lyric/hook/module/SystemUILyric.kt
@@ -423,20 +423,22 @@ class SystemUILyric : BaseHook() {
             }
         }
         loadClassOrNull("com.android.systemui.statusbar.phone.CentralSurfacesImpl").isNotNull {
-            it.methodFinder().filterByName("barMode").first().createHook {
-                after { hook ->
-                    val mode = hook.result as Int
-                    val mIsFullscreen = hook.thisObject.getObjectField("mIsFullscreen") as Boolean
-                    if (mIsFullscreen && (mode == 0 || mode == 6)) {
-                        if (!isHiding) {
-                            if (isPlaying) {
-                                shouldHiding(true)
-                                hideLyric()
+            it.methodFinder().filterByName("barMode").firstOrNull().ifNotNull { method ->
+                method.createHook {
+                    after { hook ->
+                        val mode = hook.result as Int
+                        val mIsFullscreen = hook.thisObject.getObjectField("mIsFullscreen") as Boolean
+                        if (mIsFullscreen && (mode == 0 || mode == 6)) {
+                            if (!isHiding) {
+                                if (isPlaying) {
+                                    shouldHiding(true)
+                                    hideLyric()
+                                }
                             }
-                        }
-                    } else if ((!mIsFullscreen && mode == 0) || (mIsFullscreen && mode == 1))
-                        shouldHiding(false)
-                    "statusBar state: $mode, fullscreen: $mIsFullscreen".log()
+                        } else if ((!mIsFullscreen && mode == 0) || (mIsFullscreen && mode == 1))
+                            shouldHiding(false)
+                        "statusBar state: $mode, fullscreen: $mIsFullscreen".log()
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/statusbar/lyric/tools/Tools.kt
+++ b/app/src/main/kotlin/statusbar/lyric/tools/Tools.kt
@@ -222,8 +222,19 @@ object Tools {
         return false
     }
 
-    fun Any.getObjectField(fieldName: String): Any {
+    inline fun <T> T?.ifNotNull(callback: (T) -> Any?): Any? {
+        if (this != null) {
+            return callback(this)
+        }
+        return null
+    }
+
+    fun Any.getObjectField(fieldName: String): Any? {
         return XposedHelpers.getObjectField(this, fieldName)
+    }
+
+    fun Any?.callMethod(methodName: String, vararg args: Any): Any? {
+        return XposedHelpers.callMethod(this, methodName, *args)
     }
 
     fun Any?.isNull() = this == null


### PR DESCRIPTION
比较大的更改，适配了 OS2 的焦点通知！
现在点击状态栏 隐藏/显示 歌词支持隐藏焦点通知，同时保持焦点通知点击跳转应用的功能。
